### PR TITLE
Allow per-column sort functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ $("div#id").jstree({
 	* `valueClassPrefix`: a prefix to add to the valueClass to use as a class on this cell
 	* `wideValueClass`: the attribute on the node to use as a class on this cell - added to the <div>
 	* `wideValueClassPrefix`: a prefix to add to the wideValueClass to use as a class on this cell
+	* `sort`: a function to sort the column when the header is clicked - does not replace the default sorting function used for the first column
 * `resizable`: true/false if the columns should be resizable. Defaults to false.
 * `draggable`: true/false if the columns should be draggable (requires jQuery UI with sortable plugin). Defaults to false.
 * `stateful`: true/false. If true, then whenever a column width is resized, it will store it in html5 localStorage, if available. Defaults to false.

--- a/jstreetable.js
+++ b/jstreetable.js
@@ -262,7 +262,7 @@
 								bigger = (valueA > valueB ? 1 : -1);
 							}
 						}else{
-							// No value is first
+							// undefined is second
 							if(valueA){
 								bigger = 1;
 							}else if(valueB){

--- a/jstreetable.js
+++ b/jstreetable.js
@@ -31,7 +31,7 @@
 	SPECIAL_TITLE = "_DATA_", LEVELINDENT = 24, styled = false, TABLECELLID_PREFIX = "jstable_",TABLECELLID_POSTFIX = "_col",
 		MINCOLWIDTH = 10,
 		findDataCell = function (from,id) {
-			return from.find("div["+NODE_DATA_ATTR+'="'+id+'"]');
+			return from.find("div["+NODE_DATA_ATTR+'="'+ escapeId(id) +'"]');
 		},
 		isClickedSep = false, toResize = null, oldMouseX = 0, newMouseX = 0;
 	

--- a/jstreetable.js
+++ b/jstreetable.js
@@ -148,6 +148,7 @@
 					draggable : s.draggable,
 					stateful: s.stateful,
 					indent: 0,
+					sortFn: [],
 					sortOrder: 'text',
 					sortAsc: true,
 					fixedHeader: s.fixedHeader !== false,
@@ -160,6 +161,10 @@
 				}, cols = gs.columns, treecol = 0;
 				// find which column our tree shuld go in
 				for (i=0;i<s.columns.length;i++) {
+					//Save sort function
+					if (i!==0 && s.columns[i].sort) {
+						gs.sortFn[s.columns[i].value] = s.columns[i].sort;
+					}
 					if (s.columns[i].tree) {
 						// save which column it was
 						treecol = i;
@@ -244,17 +249,37 @@
 					var bigger;
 
 					if (gs.sortOrder==='text') {
-						bigger = (defaultSort(a, b) === 1);
+						bigger = defaultSort(a, b);
 					} else {
-						var nodeA = this.get_node(a);
-						var nodeB = this.get_node(b);
-						bigger = nodeA.data[gs.sortOrder] > nodeB.data[gs.sortOrder];
+						var valueA = this.get_node(a).data[gs.sortOrder];
+						var valueB = this.get_node(b).data[gs.sortOrder];
+
+						if(valueA && valueB){
+							if(gs.sortFn[gs.sortOrder]){
+								bigger = gs.sortFn[gs.sortOrder](valueA, valueB);
+							}else{
+								// Default sorting
+								bigger = (valueA > valueB ? 1 : -1);
+							}
+						}else{
+							// No value is first
+							if(valueA){
+								bigger = 1;
+							}else if(valueB){
+								bigger = -1;
+							}else{
+								// Compare two nodes without values
+								bigger = defaultSort(a, b);
+							}
+						}
 					}
 
-					if (gs.sortAsc===false)
-						bigger = !bigger;
+					if (gs.sortAsc===false){
+						bigger = -bigger;
 
-					return bigger ? 1 : -1;
+					}
+					
+					return bigger;
 				};
 				
 				// sortable columns when jQuery UI is available

--- a/jstreetable.js
+++ b/jstreetable.js
@@ -251,12 +251,13 @@
 					if (gs.sortOrder==='text') {
 						bigger = defaultSort(a, b);
 					} else {
-						var valueA = this.get_node(a).data[gs.sortOrder];
-						var valueB = this.get_node(b).data[gs.sortOrder];
-
+						var nodeA = this.get_node(a);
+						var nodeB = this.get_node(b);
+						var valueA = nodeA.data[gs.sortOrder];
+						var valueB = nodeB.data[gs.sortOrder];
 						if(valueA && valueB){
 							if(gs.sortFn[gs.sortOrder]){
-								bigger = gs.sortFn[gs.sortOrder](valueA, valueB);
+								bigger = gs.sortFn[gs.sortOrder](valueA, valueB, nodeA, nodeB);
 							}else{
 								// Default sorting
 								bigger = (valueA > valueB ? 1 : -1);


### PR DESCRIPTION
Add the ability to specify a sort function for each column (except the first one which uses the default sorting function of the plugin).
The functions are saved inside the sortFn array and called based on the column used to sort.

Each function follow the POSITIVE/NEGATIVE/NUL scheme to compare elements. Reverting to a default compare if the function is not specified.