### PR TITLE
If width is decimals, there is a bug.

### DIFF
--- a/jstreetable.js
+++ b/jstreetable.js
@@ -855,7 +855,7 @@
 				var item = $(this), width;
 				item.css("position", "absolute");
 				item.css("width", "auto");
-				width = item.outerWidth();
+				width = item.outerWidth() + 1;
 				item.css("position", "static");
 
 				if (width>newWidth) {


### PR DESCRIPTION
While outerWidth() only gets integer, the new width may be smaller than the true width.

I add 1 to solve the problem temporarily.