### PR TITLE
Add "main" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"version": "1.0.0",
 	"url": "https://github.com/adamjimenez/jstree-table",
 	"author": {"name":"Adam Jimenez","url":"https://github.com/adamjimenez"},
+	"main": "jstreetable.js",
 	"dependencies": {
     	"jstree":">=3.0.0"
 	},


### PR DESCRIPTION
Add `"main": "jstreetable.js"` to package.json, so that build tools can find the file to import.

Eg. 
```js
import 'jstreetable';
```